### PR TITLE
Set alternative DB connection per model

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -192,7 +192,7 @@ class Model extends Eloquent
      */
     protected function configureDatabaseConnection()
     {
-        if (defined('LARAVEL_START') and function_exists('config')) {
+        if (!isset($this->connection) && defined('LARAVEL_START') and function_exists('config')) {
             if ($connection = config('corcel.connection')) {
                 $this->connection = $connection;
             } elseif (config('database.connections.corcel')) {


### PR DESCRIPTION
When using a multisite solution, sometimes you want to create a model from another site. This means that you have to create a new database connection. With this feature you can set the $connection property (like eloquent models) to your model to get data from another database (or other prefixed table)